### PR TITLE
Bug Fix the global sync was not resumed correctly

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -677,7 +677,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 //    {
 //        [self.setPinCoordinatorBridgePresenter dismiss];
 //        self.setPinCoordinatorBridgePresenter = nil;
-//        [self afterAppUnlockedByPin:application];
+        [self afterAppUnlockedByPin:application];
 //    }
 }
 

--- a/changelog.d/527.bugfix
+++ b/changelog.d/527.bugfix
@@ -1,0 +1,1 @@
+Messages are missing in the room timelines


### PR DESCRIPTION
When we commented the code related to the Biometrics & Pin Code, we broke the resume process. The method `afterAppUnlockedByPin` should be called by default to pursue application resume
Todo : support Biometrics & Pin Code in Tchap

#527
