### PR TITLE
Fix a crash at startup on iPad

### DIFF
--- a/Riot/Assets/Images.xcassets/launch_screen_logo.imageset/Contents.json
+++ b/Riot/Assets/Images.xcassets/launch_screen_logo.imageset/Contents.json
@@ -1,31 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    },
-    {
-      "unassigned" : true,
       "filename" : "launch_screen_logo.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "unassigned" : true,
       "filename" : "launch_screen_logo@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "unassigned" : true,
       "filename" : "launch_screen_logo@3x.png",
       "idiom" : "universal",
       "scale" : "3x"


### PR DESCRIPTION
The application crashed every times at Startup on iPad, due to missing image association for those devices.