### PR TITLE
[Salons] Replace section name "Conversations" with "Salons" and restore "People" navigation title

### DIFF
--- a/Riot/Assets/fr.lproj/Vector.strings
+++ b/Riot/Assets/fr.lproj/Vector.strings
@@ -110,8 +110,8 @@
 "room_recents_join_room_prompt" = "Saisir un identifiant ou un alias de salon";
 // People tab
 "people_invites_section" = "INVITATIONS";
-"people_conversation_section" = "DISCUSSIONS";
-"people_no_conversation" = "Aucune discussion";
+"people_conversation_section" = "SALONS";
+"people_no_conversation" = "Aucun salon";
 // Rooms tab
 "room_directory_no_public_room" = "Aucun forum disponible";
 // Groups tab

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -635,8 +635,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
         }
         else
         {
-            // Tchap: Update section name to `Conversations`
-            title = NSLocalizedStringFromTable(@"conversations_main_section", @"Tchap", @"").uppercaseString;
+            title = [VectorL10n roomRecentsConversationsSection];
         }
     }
     else if (section == directorySection)

--- a/Riot/Modules/People/PeopleViewController.m
+++ b/Riot/Modules/People/PeopleViewController.m
@@ -26,7 +26,7 @@
 
 #import "GeneratedInterface-Swift.h"
 
-@interface PeopleViewController () //<SpaceMembersCoordinatorBridgePresenterDelegate>
+@interface PeopleViewController () <MasterTabBarItemDisplayProtocol>//<SpaceMembersCoordinatorBridgePresenterDelegate>
 {
     NSInteger          directRoomsSectionNumber;
     RecentsDataSource *recentsDataSource;

--- a/Riot/Modules/TabBar/TabBarCoordinator.swift
+++ b/Riot/Modules/TabBar/TabBarCoordinator.swift
@@ -280,8 +280,7 @@ final class TabBarCoordinator: NSObject, TabBarCoordinatorType {
         let roomsViewController: RoomsViewController = RoomsViewController.instantiate()
         roomsViewController.roomsViewDelegate = self
         roomsViewController.tabBarItem.tag = Int(TABBAR_ROOMS_INDEX)
-        // Tchap: Update accessibility label name to `Conversations`
-        roomsViewController.accessibilityLabel = TchapL10n.conversationsTabTitle
+        roomsViewController.accessibilityLabel = VectorL10n.titleRooms
         roomsViewController.userIndicatorStore = UserIndicatorStore(presenter: indicatorPresenter)
         return roomsViewController
     }

--- a/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
+++ b/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
@@ -88,11 +88,8 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 // MARK: Conversations
-"conversations_tab_title" = "Conversations";
 "conversations_invites_section" = "Invitations";
-"conversations_main_section" = "Conversations";
 "conversations_directory_section" = "Salons forums";
-"conversations_no_conversation" = "Aucune conversation";
 "conversations_start_chat_action" = "Nouvelle discussion";
 "conversations_create_room_action" = "Nouveau salon";
 "conversations_access_to_public_rooms_action" = "Accéder à un salon forum";

--- a/Tchap/Generated/Strings.swift
+++ b/Tchap/Generated/Strings.swift
@@ -126,14 +126,8 @@ internal enum TchapL10n {
   internal static let conversationsInviteJoin = TchapL10n.tr("Tchap", "conversations_invite_join")
   /// Invitations
   internal static let conversationsInvitesSection = TchapL10n.tr("Tchap", "conversations_invites_section")
-  /// Conversations
-  internal static let conversationsMainSection = TchapL10n.tr("Tchap", "conversations_main_section")
-  /// Aucune conversation
-  internal static let conversationsNoConversation = TchapL10n.tr("Tchap", "conversations_no_conversation")
   /// Nouvelle discussion
   internal static let conversationsStartChatAction = TchapL10n.tr("Tchap", "conversations_start_chat_action")
-  /// Conversations
-  internal static let conversationsTabTitle = TchapL10n.tr("Tchap", "conversations_tab_title")
   /// Nouvelle discussion
   internal static let createNewDiscussionTitle = TchapL10n.tr("Tchap", "create_new_discussion_title")
   /// Vérifier l’appareil

--- a/changelog.d/563.change
+++ b/changelog.d/563.change
@@ -1,0 +1,1 @@
+[Salons] Replace section name "Conversations" with "Salons"


### PR DESCRIPTION
#548 + #563 