### PR TITLE
Fix Info.plist file path for apps targets

### DIFF
--- a/Tchap/target.yml
+++ b/Tchap/target.yml
@@ -65,6 +65,9 @@ targetTemplates:
       shell: /bin/sh
       script: "\"${PODS_ROOT}/SwiftGen/bin/swiftgen\" config run --config \"Tools/SwiftGen/swiftgen-config.yml\"\n"
 
+    settings:
+      INFOPLIST_FILE: "${target_name}/SupportingFiles/Info.plist"
+
     sources:
     - path: ../Config/AppConfiguration.swift
     - path: ../Config/Project.xcconfig


### PR DESCRIPTION
After this PR #682 , the path for `Info.plist` file for all apps targets was the same (`Tchap/SupportingFiles/Info.plist`).
But, the path for Btchap and DevTchap was not the right one, and AppStoreConnect rejected Btchap for this, due to `Invalid Export Compliance Code`.