### PR TITLE
Accepting CGU is not mandatory on account creation

### DIFF
--- a/RiotSwiftUI/Modules/Authentication/VerifyEmail/View/AuthenticationVerifyEmailForm.swift
+++ b/RiotSwiftUI/Modules/Authentication/VerifyEmail/View/AuthenticationVerifyEmailForm.swift
@@ -79,21 +79,17 @@ struct AuthenticationVerifyEmailForm: View {
 //                textField
 //                    .onSubmit(submit)
 //            } else {
-                textField
+
+            textField
+                .introspectTextField {
+                    $0.becomeFirstResponder()
+                }
+                
+
 //            }
             
             // Tchap: Add password management
-            RoundedBorderTextField(title: nil,
-                                   placeHolder: VectorL10n.authPasswordPlaceholder,
-                                   text: $viewModel.password,
-                                           footerText: VectorL10n.authenticationRegistrationPasswordFooter,
-                                   isError: viewModel.viewState.hasEditedPassword && viewModel.viewState.isPasswordInvalid,
-                                   isFirstResponder: isEditingTextField,//isPasswordFocused,
-                                   configuration: UIKitTextInputConfiguration(returnKeyType: .done,
-                                                                              isSecureTextEntry: true),
-                                   onEditingChanged: nil,//passwordEditingChanged,
-                                   onCommit: submit)
-            .accessibilityIdentifier("passwordTextField")
+            passwordField
             
             // Tchap: Add Terms and Conditions buttons
             HStack(alignment: .center, spacing: 8) {
@@ -133,6 +129,20 @@ struct AuthenticationVerifyEmailForm: View {
         .accessibilityIdentifier("addressTextField")
     }
     
+    var passwordField: some View {
+        RoundedBorderTextField(title: nil,
+                               placeHolder: VectorL10n.authPasswordPlaceholder,
+                               text: $viewModel.password,
+                               footerText: VectorL10n.authenticationRegistrationPasswordFooter,
+                               isError: viewModel.viewState.hasEditedPassword && viewModel.viewState.isPasswordInvalid,
+                               isFirstResponder: isEditingTextField,//isPasswordFocused,
+                               configuration: UIKitTextInputConfiguration(returnKeyType: .done,
+                                                                          isSecureTextEntry: true),
+                               onEditingChanged: nil,//passwordEditingChanged,
+                               onCommit: nil)
+        .accessibilityIdentifier("passwordTextField")
+    }
+
     // Tchap: Prepare the account creation when email and pwd are ready
     func submit() {
         guard !viewModel.viewState.hasInvalidAddress else { return }

--- a/changelog.d/736.bugfix
+++ b/changelog.d/736.bugfix
@@ -1,0 +1,1 @@
+Accepting CGU is not mandatory on account creation


### PR DESCRIPTION
[issue #736](https://github.com/tchapgouv/tchap-ios/issues/736)

Prevent the submission of the form when tapping 'Done' on keyboard after filling password.
Now, it just dismiss the keyboard as usual.

In addition, when the form is first displayed, the email field is set as first responder so that it is automatically activated for input and the keyboard is shown.