### PR TITLE
[Paramètres] Masquer l'option "Nom d'affichage" (#848 )

### DIFF
--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -376,7 +376,10 @@ ChangePasswordCoordinatorBridgePresenterDelegate>
     
     Section *sectionUserSettings = [Section sectionWithTag:SECTION_TAG_USER_SETTINGS];
     [sectionUserSettings addRowWithTag:USER_SETTINGS_PROFILE_PICTURE_INDEX];
-    [sectionUserSettings addRowWithTag:USER_SETTINGS_DISPLAYNAME_INDEX];
+    
+    // Tchap: Remove Display Name because the function is blocked by back-end
+        [sectionUserSettings addRowWithTag:USER_SETTINGS_DISPLAYNAME_INDEX];
+    
     if (RiotSettings.shared.settingsScreenShowChangePassword)
     {
         [sectionUserSettings addRowWithTag:USER_SETTINGS_CHANGE_PASSWORD_INDEX];

--- a/changelog.d/848.change
+++ b/changelog.d/848.change
@@ -1,0 +1,1 @@
+[Paramètres] Masquer l'option "Nom d'affichage" (#848)


### PR DESCRIPTION
Fix #848 

Avant 
![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/5422357e-b513-4144-b5f2-9e49f337fc2a)

Après
![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/0c37e9d7-a734-48c8-a670-8f947f768d6e)
