### PR TITLE
[RageShake] Limiter la taille des fichiers de logs (#841 )

### DIFF
--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -277,7 +277,7 @@ NSString *const kLegacyAppDelegateDidLoginNotification = @"kLegacyAppDelegateDid
     
     MXLogConfiguration *configuration = [[MXLogConfiguration alloc] init];
     configuration.logLevel = MXLogLevelVerbose;
-    configuration.logFilesSizeLimit = 100 * 1024 * 1024; // 100MB
+    configuration.logFilesSizeLimit = 10 * 1024 * 1024; // Tchap : limit logfiles size to 10MB else RageShake can be refused by back-end (error 500).
     configuration.maxLogFilesCount = 50;
     
     // Redirect NSLogs to files only if we are not debugging

--- a/Riot/Modules/BugReport/BugReportViewController.m
+++ b/Riot/Modules/BugReport/BugReportViewController.m
@@ -384,7 +384,7 @@
         }];
     
     [bugReportRestClient vc_sendBugReportWithDescription:bugReportDescription
-                                                sendLogs:false /*_sendLogs */ // Tchap : force to not send log files becasue they are too big and generate an error 500 on backend.  
+                                                sendLogs:_sendLogs
                                             sendCrashLog:_reportCrash
                                                sendFiles:files
                                         additionalLabels:nil

--- a/changelog.d/841.change
+++ b/changelog.d/841.change
@@ -1,0 +1,1 @@
+[RageShake] Les logs transmis peuvent être trop gros pour le serveur (#841)


### PR DESCRIPTION
Fix #841 

Des fichiers de logs trop important peuvent bloquer la réception des RageShake par le back-end.

Une parade précédente a été de forcer la non transmission des fichiers de logs : https://github.com/tchapgouv/tchap-ios/issues/789

Un paramètre global de limitation de l'accumulation de fichiers de logs existe dans Element : https://github.com/vector-im/element-ios/issues/7559#issuecomment-1570690431

Annuler la parade précédente et limiter la taille des fichiers de logs de 100Mo à 10Mo.