### PR TITLE
DM external : affichage des rooms en attendant que les correspondants…

### DIFF
--- a/Riot/Assets/fr.lproj/Vector.strings
+++ b/Riot/Assets/fr.lproj/Vector.strings
@@ -2488,11 +2488,15 @@
 // Mark: - Space Selector
 
 "space_selector_title" = "Mes espaces";
-"room_invites_empty_view_information" = "C’est ici que vos invitations apparaîtront.";
 
 // Mark: - Room invites
 
 "room_invites_empty_view_title" = "Rien de neuf.";
+"room_invites_empty_view_information" = "C’est ici que vos invitations apparaîtront.";
+
+"room_waiting_other_participants_title" = "En attente d'invités sur %@"; // Tchap
+"room_waiting_other_participants_message" = "Dès que les invités auront rejoint %@, vous pourrez discuter avec eux et le salon sera chiffré de bout en bout."; // Tchap
+
 "all_chats_edit_menu_space_settings" = "Paramètres de l’espace";
 "all_chats_edit_menu_leave_space" = "Quitter %@";
 "all_chats_user_menu_settings" = "Paramètres utilisateur";

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -152,31 +152,11 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
 }
 - (NSArray<id<MXRoomSummaryProtocol>> *)breadcrumbsRoomCellDataArray
 {
-    // Tchap: Hide the rooms created to invite some non-tchap contact by email.
-    NSMutableArray<id<MXRoomSummaryProtocol>> *rooms = [NSMutableArray new];
-    for (MXRoom *room in self.recentsListService.breadcrumbsRoomListData.rooms)
-    {
-        if (room.isDirect && [MXTools isEmailAddress:room.directUserId])
-        {
-            continue;
-        }
-        [rooms addObject:room];
-    }
-    return rooms;
+    return self.recentsListService.breadcrumbsRoomListData.rooms;
 }
 - (NSArray<id<MXRoomSummaryProtocol>> *)allChatsRoomCellDataArray
 {
-    // Tchap: Hide the rooms created to invite some non-tchap contact by email.
-    NSMutableArray<id<MXRoomSummaryProtocol>> *rooms = [NSMutableArray new];
-    for (MXRoom *room in self.recentsListService.allChatsRoomListData.rooms)
-    {
-        if (room.isDirect && [MXTools isEmailAddress:room.directUserId])
-        {
-            continue;
-        }
-        [rooms addObject:room];
-    }
-    return rooms;
+    return self.recentsListService.allChatsRoomListData.rooms;
 }
 
 - (NSInteger)totalVisibleItemCount

--- a/changelog.d/876.bugfix
+++ b/changelog.d/876.bugfix
@@ -1,0 +1,1 @@
+Suppression du masquage des salons de messagerie direct (DM) avec externes pendant l'attente de l'inscription des correspondants


### PR DESCRIPTION
Fix #876 

Réactiver l'affichage des rooms DM external dans la liste générale des rooms en attendant que l'externe arrive sur Tchap.

Traduction d'un texte d'entête d'attente sur la rom en état d'attente.

![simulator_screenshot_0F0186CB-86A3-4B41-9262-647E2FEAAA7B](https://github.com/tchapgouv/tchap-ios/assets/18608158/300d6319-b94d-42a1-823f-9ea6df0d6050)
