### PR TITLE
896 respecter le reglage de taille de texte du systeme

### DIFF
--- a/Riot/Modules/Common/SectionHeaders/TabListView.swift
+++ b/Riot/Modules/Common/SectionHeaders/TabListView.swift
@@ -171,6 +171,8 @@ class TabListView: UIView {
         for (index, item) in items.enumerated() {
             let button = UIButton(type: .system)
             button.titleLabel?.font = itemFont
+            // Tchap: automatically adjust button font size dynamically when user change the setting.
+            button.vc_adjustsFontForContentSizeCategory = true
             button.setTitle(item.text, for: .normal)
             button.setImage(item.icon?.withRenderingMode(.alwaysTemplate), for: .normal)
             button.contentEdgeInsets = UIEdgeInsets(top: 0, left: Constants.itemSpacing / 2, bottom: 0, right: Constants.itemSpacing / 2)

--- a/Riot/Modules/MatrixKit/Views/MXKMessageTextView.m
+++ b/Riot/Modules/MatrixKit/Views/MXKMessageTextView.m
@@ -78,6 +78,9 @@
         // forcing the layoutManager to redraw the glyphs at all NSAttachment positions.
         [self vc_invalidateTextAttachmentsDisplay];
     }
+    
+    // Tchap: set text type to prefered font to rerspect user text size
+    self.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 - (void)registerPillView:(UIView *)pillView

--- a/Riot/Modules/MatrixKit/Views/MXKMessageTextView.m
+++ b/Riot/Modules/MatrixKit/Views/MXKMessageTextView.m
@@ -27,6 +27,29 @@
 
 @implementation MXKMessageTextView
 
+// Tchap: automatically adjust message font size dynamically when user change the setting.
+- (id)initWithFrame:(CGRect)frame textContainer:(NSTextContainer *)textContainer
+{
+    self = [super initWithFrame:frame textContainer:textContainer];
+    
+    if (self) {
+        [self setAdjustsFontForContentSizeCategory:YES];
+    }
+    
+    return self;
+}
+
+// Tchap: automatically adjust message font size dynamically when user change the setting.
+- (id)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    
+    if (self) {
+        [self setAdjustsFontForContentSizeCategory:YES];
+    }
+    
+    return self;
+}
+
 - (BOOL)canBecomeFirstResponder
 {
     return NO;

--- a/changelog.d/896.change
+++ b/changelog.d/896.change
@@ -1,0 +1,1 @@
+Le texte des messages dans un salon respecte le réglage de taille de texte de l’utilisateur (possibilité de zoom)


### PR DESCRIPTION
Fix #896 

Ce n'est pas parfait. Ça fait le job pour le besoin des utilisateurs.

Cela sera raffiné par des passes ultérieures.

![IMG_7958](https://github.com/tchapgouv/tchap-ios/assets/18608158/36cde7ac-ac86-47b1-ac3b-12073a95e88a)
