### PR TITLE
Problème après upgrade v261

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -956,7 +956,7 @@ Tap the + to start adding people.";
 "security_settings_complete_security_alert_message" = "You should complete security on your current session first.";
 
 "security_settings_coming_soon" = "Sorry. This action is not available on %@ iOS yet. Please use another Matrix client to set it up. %@ iOS will use it.";
-"security_settings_user_password_description" = "Confirm your identity by entering your Matrix account password";
+"security_settings_user_password_description" = "Confirm your identity by entering your account password"; // Tchap
 
 // Manage session
 "manage_session_title" = "Manage session";
@@ -1908,7 +1908,7 @@ Tap the + to start adding people.";
 "secrets_reset_warning_title" = "If you reset everything";
 "secrets_reset_warning_message" = "You will restart with no history, no messages, trusted devices or trusted users.";
 "secrets_reset_reset_action" = "Reset";
-"secrets_reset_authentication_message" = "Enter your Matrix account password to confirm";
+"secrets_reset_authentication_message" = "Enter your account password to confirm"; // Tchap
 
 // MARK: - Cross-signing
 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1841,7 +1841,7 @@ Tap the + to start adding people.";
 // MARK: - Secrets recovery
 
 "secrets_recovery_reset_action_part_1" = "You lost your Recovery Code?"; // Tchap
-"secrets_recovery_reset_action_part_2" = "Generate a new Code"; // Tchap
+"secrets_recovery_reset_action_part_2" = "\n\nGenerate a new Code"; // Tchap
 
 // Recover with passphrase
 

--- a/Riot/Assets/fr.lproj/Vector.strings
+++ b/Riot/Assets/fr.lproj/Vector.strings
@@ -1324,7 +1324,7 @@
 "social_login_button_title_sign_in" = "Se connecter avec %@";
 "secrets_setup_recovery_passphrase_summary_information" = "Mémorisez votre phrase de sécurité. Elle peut être utilisée pour déverrouiller vos messages et données chiffrés.";
 "secrets_setup_recovery_passphrase_summary_title" = "Enregistrer votre phrase de sécurité";
-"secrets_recovery_reset_action_part_2" = "Générer un nouveau code"; // Tchap
+"secrets_recovery_reset_action_part_2" = "\n\nGénérer un nouveau code"; // Tchap
 
 // MARK: - Secrets recovery
 

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -439,6 +439,11 @@ final class RiotSettings: NSObject {
     @UserDefault(key: "tchapSecureBackupNextDisplayDate", defaultValue: Date.init(timeIntervalSince1970: 0), storage: defaults)
     var tchapSecureBackupNextDisplayDate
     
+    // Tchap has tried to automatically activate cross-signing.
+    // This automatic activation must be tried only once because if it fails, it could pro;pt user each time the application is activated.
+    @UserDefault(key: "tchapCrossSigningAutoActivationTried", defaultValue: false, storage: defaults)
+    var tchapCrossSigningAutoActivationTried
+    
 }
 
 // MARK: - RiotSettings notification constants

--- a/Riot/Modules/Home/HomeViewController.m
+++ b/Riot/Modules/Home/HomeViewController.m
@@ -109,6 +109,14 @@
 // Tchap: set-up cross-signing auto-activation
 - (void)tchapSetupCrossSigningAutoActivation
 {
+    if( RiotSettings.shared.tchapCrossSigningAutoActivationTried == YES )
+    {
+        // Don't retry to auto-activate cross-signing again.
+        // It has already been tried in optimal conditions and seems to not work.
+        // Don't retry because it can prompt the user to enter its account password each time.
+        return;
+    }
+    
     // Tchap: listen to Tchap syncDone notification to check the status of the cross-signing after account info are updated.
     if (tchapSyncDoneListener == nil)
     {
@@ -135,6 +143,7 @@
                 && (session.crypto.crossSigning.state == MXCrossSigningStateNotBootstrapped || session.crypto.crossSigning.state == MXCrossSigningStateCrossSigningExists) )
             {
                 [strongSelf showCrossSigningSetup];
+                RiotSettings.shared.tchapCrossSigningAutoActivationTried = YES;
             }
         }];
     }

--- a/Riot/Modules/Secrets/Reset/SecretsResetCoordinator.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetCoordinator.swift
@@ -58,29 +58,27 @@ final class SecretsResetCoordinator: SecretsResetCoordinatorType {
     }
     
     // MARK: - Private
-    // TODO: Tchap: Support Reauthentication (SecretsReset)
-//    private func showAuthentication(with request: AuthenticatedEndpointRequest) {
-//
-//        let reauthenticationCoordinatorParameters =  ReauthenticationCoordinatorParameters(session: self.session,
-//                                                                                           presenter: self.toPresentable(),
-//                                                                                           title: nil,
-//                                                                                           message: VectorL10n.secretsResetAuthenticationMessage,
-//                                                                                           authenticatedEndpointRequest: request)
-//
-//        let coordinator = ReauthenticationCoordinator(parameters: reauthenticationCoordinatorParameters)
-//        coordinator.delegate = self
-//        coordinator.start()
-//        self.add(childCoordinator: coordinator)
-//    }
+    private func showAuthentication(with request: AuthenticatedEndpointRequest) {
+
+        let reauthenticationCoordinatorParameters =  ReauthenticationCoordinatorParameters(session: self.session,
+                                                                                           presenter: self.toPresentable(),
+                                                                                           title: nil,
+                                                                                           message: VectorL10n.secretsResetAuthenticationMessage,
+                                                                                           authenticatedEndpointRequest: request)
+
+        let coordinator = ReauthenticationCoordinator(parameters: reauthenticationCoordinatorParameters)
+        coordinator.delegate = self
+        coordinator.start()
+        self.add(childCoordinator: coordinator)
+    }
 }
 
 // MARK: - SecretsResetViewModelCoordinatorDelegate
 extension SecretsResetCoordinator: SecretsResetViewModelCoordinatorDelegate {
     
-    // TODO: Tchap: Support Reauthentication (SecretsReset)
-//    func secretsResetViewModel(_ viewModel: SecretsResetViewModelType, needsToAuthenticateWith request: AuthenticatedEndpointRequest) {
-//        self.showAuthentication(with: request)
-//    }
+    func secretsResetViewModel(_ viewModel: SecretsResetViewModelType, needsToAuthenticateWith request: AuthenticatedEndpointRequest) {
+        self.showAuthentication(with: request)
+    }
     
     func secretsResetViewModelDidResetSecrets(_ viewModel: SecretsResetViewModelType) {
         self.delegate?.secretsResetCoordinatorDidResetSecrets(self)
@@ -92,20 +90,19 @@ extension SecretsResetCoordinator: SecretsResetViewModelCoordinatorDelegate {
 }
 
 // MARK: - ReauthenticationCoordinatorDelegate
-// TODO: Tchap: Support Reauthentication (SecretsReset)
-// extension SecretsResetCoordinator: ReauthenticationCoordinatorDelegate {
-//    
-//     func reauthenticationCoordinatorDidComplete(_ coordinator: ReauthenticationCoordinatorType, withAuthenticationParameters authenticationParameters: [String: Any]?) {
-//         self.secretsResetViewModel.process(viewAction: .authenticationInfoEntered(authenticationParameters ?? [:]))
-//     }
-//    
-//     func reauthenticationCoordinatorDidCancel(_ coordinator: ReauthenticationCoordinatorType) {
-//         self.secretsResetViewModel.process(viewAction: .authenticationCancelled)
-//         self.remove(childCoordinator: coordinator)
-//     }
-//    
-//     func reauthenticationCoordinator(_ coordinator: ReauthenticationCoordinatorType, didFailWithError error: Error) {
-//         self.secretsResetViewModel.update(viewState: .error(error))
-//         self.remove(childCoordinator: coordinator)
-//     }
-// }
+extension SecretsResetCoordinator: ReauthenticationCoordinatorDelegate {
+    
+     func reauthenticationCoordinatorDidComplete(_ coordinator: ReauthenticationCoordinatorType, withAuthenticationParameters authenticationParameters: [String: Any]?) {
+         self.secretsResetViewModel.process(viewAction: .authenticationInfoEntered(authenticationParameters ?? [:]))
+     }
+    
+     func reauthenticationCoordinatorDidCancel(_ coordinator: ReauthenticationCoordinatorType) {
+         self.secretsResetViewModel.process(viewAction: .authenticationCancelled)
+         self.remove(childCoordinator: coordinator)
+     }
+    
+     func reauthenticationCoordinator(_ coordinator: ReauthenticationCoordinatorType, didFailWithError error: Error) {
+         self.secretsResetViewModel.update(viewState: .error(error))
+         self.remove(childCoordinator: coordinator)
+     }
+ }

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewModel.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewModel.swift
@@ -97,11 +97,10 @@ final class SecretsResetViewModel: SecretsResetViewModelType {
     }
     
     private func askAuthentication() {
-        // TODO: Tchap: Support Reauthentication (SecretsReset)
-//        let setupCrossSigningRequest = self.crossSigningService.setupCrossSigningRequest()
-//        self.coordinatorDelegate?.secretsResetViewModel(self, needsToAuthenticateWith: setupCrossSigningRequest)
-//
-//        self.update(viewState: .resetting)
+        let setupCrossSigningRequest = self.crossSigningService.setupCrossSigningRequest()
+        self.coordinatorDelegate?.secretsResetViewModel(self, needsToAuthenticateWith: setupCrossSigningRequest)
+
+        self.update(viewState: .resetting)
     }
     
     private func authenticationCancelled() {

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewModelType.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewModelType.swift
@@ -23,8 +23,7 @@ protocol SecretsResetViewModelViewDelegate: AnyObject {
 }
 
 protocol SecretsResetViewModelCoordinatorDelegate: AnyObject {
-    // TODO: Tchap: Support Reauthentication (SecretsReset)
-//    func secretsResetViewModel(_ viewModel: SecretsResetViewModelType, needsToAuthenticateWith request: AuthenticatedEndpointRequest)
+    func secretsResetViewModel(_ viewModel: SecretsResetViewModelType, needsToAuthenticateWith request: AuthenticatedEndpointRequest)
     func secretsResetViewModelDidResetSecrets(_ viewModel: SecretsResetViewModelType)
     func secretsResetViewModelDidCancel(_ viewModel: SecretsResetViewModelType)
 }

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -50,7 +50,7 @@ enum
 enum {
     CROSSSIGNING_INFO,
     CROSSSIGNING_FIRST_ACTION,      // Bootstrap, Reset, Verify this session, Request keys
-//    CROSSSIGNING_SECOND_ACTION,     // Reset // Tchap : no second action
+    CROSSSIGNING_SECOND_ACTION,     // Reset
 };
 
 enum {
@@ -692,16 +692,15 @@ MXKDocumentPickerPresenterDelegate>
     NSInteger numberOfRowsInCrossSigningSection;
     
     id<MXCrossSigning> crossSigning = self.mainSession.crypto.crossSigning;
-    // Tchap : display Activate button only if cross-signing does not exist on account or if it is not trusted by this device.
     switch (crossSigning.state)
     {
-        case MXCrossSigningStateNotBootstrapped:                // Action: display Activate button
-        case MXCrossSigningStateCrossSigningExists:
+        case MXCrossSigningStateNotBootstrapped:                // Action: Bootstrap
+        case MXCrossSigningStateCanCrossSign:                   // Action: Reset
             numberOfRowsInCrossSigningSection = CROSSSIGNING_FIRST_ACTION + 1;
             break;
-        case MXCrossSigningStateTrustCrossSigning:              // Actions: no action because cross-signing already exists and is trusted
-        case MXCrossSigningStateCanCrossSign:
-            numberOfRowsInCrossSigningSection = CROSSSIGNING_FIRST_ACTION;
+        case MXCrossSigningStateCrossSigningExists:             // Actions: Verify this session, Reset
+        case MXCrossSigningStateTrustCrossSigning:              // Actions: Request keys, Reset
+            numberOfRowsInCrossSigningSection = CROSSSIGNING_FIRST_ACTION + 1;
             break;
     }
     
@@ -815,10 +814,9 @@ MXKDocumentPickerPresenterDelegate>
                 case CROSSSIGNING_FIRST_ACTION:
                     [self setUpcrossSigningButtonCellForCompletingSecurity:buttonCell];
                     break;
-                    // Tchap : no second action
-//                case CROSSSIGNING_SECOND_ACTION:
-//                    [self setUpcrossSigningButtonCellForReset:buttonCell];
-//                    break;
+                case CROSSSIGNING_SECOND_ACTION:
+                    [self setUpcrossSigningButtonCellForReset:buttonCell];
+                    break;
             }
             break;
         case MXCrossSigningStateTrustCrossSigning:              // Actions: Request keys, Reset
@@ -828,10 +826,9 @@ MXKDocumentPickerPresenterDelegate>
                     // By verifying our device again, it will get cross-signing keys by gossiping
                     [self setUpcrossSigningButtonCellForCompletingSecurity:buttonCell];
                     break;
-                    // Tchap : no second action
-//                case CROSSSIGNING_SECOND_ACTION:
-//                    [self setUpcrossSigningButtonCellForReset:buttonCell]; // Tchap : no second action
-//                    break;
+                case CROSSSIGNING_SECOND_ACTION:
+                    [self setUpcrossSigningButtonCellForReset:buttonCell];
+                    break;
             }
             break;
     }
@@ -926,7 +923,7 @@ MXKDocumentPickerPresenterDelegate>
 
 - (void)setUpcrossSigningButtonCellForReset:(MXKTableViewCellWithButton*)buttonCell
 {
-    NSString *btnTitle = [VectorL10n securitySettingsCrosssigningBootstrap]; // Tchap : simply tell user to activate cross-signing.
+    NSString *btnTitle = [VectorL10n securitySettingsCrosssigningReset];
     [buttonCell.mxkButton setTitle:btnTitle forState:UIControlStateNormal];
     [buttonCell.mxkButton setTitle:btnTitle forState:UIControlStateHighlighted];
     
@@ -1336,10 +1333,9 @@ MXKDocumentPickerPresenterDelegate>
             case CROSSSIGNING_FIRST_ACTION:
                 cell = [self crossSigningButtonCellInTableView:tableView forAction:CROSSSIGNING_FIRST_ACTION];
                 break;
-//              Tchap : no second action
-//            case CROSSSIGNING_SECOND_ACTION:
-//                cell = [self crossSigningButtonCellInTableView:tableView forAction:CROSSSIGNING_SECOND_ACTION];
-//                break;
+            case CROSSSIGNING_SECOND_ACTION:
+                cell = [self crossSigningButtonCellInTableView:tableView forAction:CROSSSIGNING_SECOND_ACTION];
+                break;
         }
     }
     else if (sectionTag == SECTION_CRYPTOGRAPHY)

--- a/changelog.d/942.change
+++ b/changelog.d/942.change
@@ -1,0 +1,3 @@
+- permettre la réinitialisation du Code de Récupération
+- permettre la réinitialisation de la signature croisée
+- ne tenter qu'une seule fois d'activer automatiquement la signature croisée


### PR DESCRIPTION
Fix #942

- permettre la réinitialisation du Code de Récupération
- permettre la réinitialisation de la signature croisée
- ne tenter qu'une seule fois d'activer automatiquement la signature croisée