### PR TITLE
Même traduction EN que le web et Android

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2773,7 +2773,7 @@ To enable access, tap Settings> Location and select Always";
 "notice_room_history_visible_to_members_from_joined_point" = "%@ made future room history visible to all room members, from the point they joined.";
 "notice_room_history_visible_to_members_from_joined_point_for_dm" = "%@ made future messages visible to everyone, from when they joined.";
 "notice_crypto_unable_to_decrypt" = "** Unable to decrypt: %@ **";
-"notice_crypto_error_unknown_inbound_session_id" = "Deciphering…"; // Tchap
+"notice_crypto_error_unknown_inbound_session_id" = "Decrypting…"; // Tchap
 "notice_sticker" = "sticker";
 "notice_in_reply_to" = "In reply to";
 "notice_voice_broadcast_live" = "Live broadcast";


### PR DESCRIPTION
Aligne le message d'erreur en cas de problème de déchiffrement sur la formulation web et Android.