### PR TITLE
Utiliser le bouton de validation Tchap en édition de message

### DIFF
--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -234,7 +234,9 @@ static const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
             self.textView.maxHeight -= kContextBarHeight;
             break;
         case RoomInputToolbarViewSendModeEdit:
-            buttonImage = AssetImages.saveIcon.image;
+            // Tchap: use Tchap icon to save edited message.
+            //            buttonImage = AssetImages.saveIcon.image;
+            buttonImage = AssetImages_tchap.sendIconTchap.image ;
             self.inputContextImageView.image = AssetImages.inputEditIcon.image;
             self.inputContextLabel.text = [VectorL10n roomMessageEditing];
 

--- a/changelog.d/986.change
+++ b/changelog.d/986.change
@@ -1,0 +1,1 @@
+Utiliser le bouton de validation Tchap en édition de message.


### PR DESCRIPTION
Fix #986 

Avant -> Après : 

![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/cc1a71df-12f4-4cd6-9581-3d0e4547a671)

