### PR TITLE
Rendre la "notification par email" disponible à tout le monde.

### DIFF
--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -269,7 +269,7 @@ final class BuildSettings: NSObject {
     static let tchapFeatureVideoOverIP = "tchapFeatureVideoOverIP"
     static var tchapFeaturesAllowedHomeServersForFeature: [String: [String]] = [
         tchapFeatureNotificationByEmail: [
-            "*"
+            tchapFeatureAnyHomeServer
         ],
         tchapFeatureVoiceOverIP: [
             "agent.dinum.tchap.gouv.fr"

--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -269,7 +269,7 @@ final class BuildSettings: NSObject {
     static let tchapFeatureVideoOverIP = "tchapFeatureVideoOverIP"
     static var tchapFeaturesAllowedHomeServersForFeature: [String: [String]] = [
         tchapFeatureNotificationByEmail: [
-            "agent.dinum.tchap.gouv.fr"
+            "*"
         ],
         tchapFeatureVoiceOverIP: [
             "agent.dinum.tchap.gouv.fr"

--- a/changelog.d/995.change
+++ b/changelog.d/995.change
@@ -1,0 +1,1 @@
+La "notification par email" est rendue disponible à tout le monde.


### PR DESCRIPTION
Fix #995 

![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/05762b47-d606-4638-84fb-14187c8b3390)
