### PR TITLE
1000 tchap annonces ameliorer la presentation

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -378,7 +378,7 @@
 "room_recents_conversations_section" = "ROOMS";
 "room_recents_no_conversation" = "No rooms";
 "room_recents_low_priority_section" = "LOW PRIORITY";
-"room_recents_server_notice_section" = "SYSTEM ALERTS";
+"room_recents_server_notice_section" = "Tchap Announcements"; // Tchap
 "room_recents_invites_section" = "INVITES";
 "room_recents_suggested_rooms_section" = "SUGGESTED ROOMS";
 "room_recents_start_chat_with" = "Start chat";

--- a/Riot/Assets/fr.lproj/Vector.strings
+++ b/Riot/Assets/fr.lproj/Vector.strings
@@ -551,7 +551,7 @@
 "settings_labs_room_members_lazy_loading" = "Chargement différé des participants des salons";
 "settings_labs_room_members_lazy_loading_error_message" = "Votre serveur d'accueil ne prend pas en charge le chargement différé des participants des salons. Réessayez plus tard.";
 "room_event_action_view_decrypted_source" = "Voir la source déchiffrée";
-"room_recents_server_notice_section" = "ALERTES SYSTÈME";
+"room_recents_server_notice_section" = "Tchap Annonces"; // Tchap
 "room_resource_limit_exceeded_message_contact_1" = " Veuillez ";
 "room_resource_limit_exceeded_message_contact_2_link" = "contacter l’administrateur de votre service";
 "room_resource_limit_exceeded_message_contact_3" = " pour continuer à l’utiliser.";

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -255,10 +255,13 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
         [types addObject:@(RecentsDataSourceSectionTypeLowPriority)];
     }
 
-    if (self.serverNoticeCellDataArray.count > 0)
-    {
-        [types addObject:@(RecentsDataSourceSectionTypeServerNotice)];
-    }
+    // Tchap: don't display server notices as separate section.
+    // Server notices are displayed in the main section "all chats"
+    // (see modification in `updateConversationFetcher` in `RecentListService`
+//    if (self.serverNoticeCellDataArray.count > 0)
+//    {
+//        [types addObject:@(RecentsDataSourceSectionTypeServerNotice)];
+//    }
 
     return [[RecentsDataSourceSections alloc] initWithSectionTypes:types.copy];
 }

--- a/Riot/Modules/Common/Recents/Service/MatrixSDK/RecentsListService.swift
+++ b/Riot/Modules/Common/Recents/Service/MatrixSDK/RecentsListService.swift
@@ -717,7 +717,12 @@ public class RecentsListService: NSObject, RecentsListServiceProtocol {
     }
     
     private func updateConversationFetcher(_ fetcher: MXRoomListDataFetcher, for mode: RecentsDataSourceMode) {
-        var notDataTypes: MXRoomSummaryDataTypes = mode == .allChats ? [.hidden, .conferenceUser, .invited, .lowPriority, .serverNotice, .space] : [.hidden, .conferenceUser, .direct, .invited, .lowPriority, .serverNotice, .space]
+        // Tchap: 
+        // don't exclude serverNotice channels from "all chats" group fetcher
+        // to get server Notices (aka "Tchap Annonces") in the main room list
+        // to be displayed as classic rooms
+//        var notDataTypes: MXRoomSummaryDataTypes = mode == .allChats ? [.hidden, .conferenceUser, .invited, .lowPriority, .serverNotice, .space] : [.hidden, .conferenceUser, .direct, .invited, .lowPriority, .serverNotice, .space]
+        var notDataTypes: MXRoomSummaryDataTypes = mode == .allChats ? [.hidden, .conferenceUser, .invited, .lowPriority, /*.serverNotice,*/ .space] : [.hidden, .conferenceUser, .direct, .invited, .lowPriority, /*.serverNotice,*/ .space]
 
         switch mode {
         case .home:

--- a/changelog.d/1000.change
+++ b/changelog.d/1000.change
@@ -1,0 +1,1 @@
+Afficher le salon "Tchap Annonces" dans le flux normal des salons


### PR DESCRIPTION
Fix #1000 

- [x] Afficher un canal "Tchap Annonces" comme un salon classique parmi les salons
- [x] Ne pas afficher de section "Alertes système" à la fin de la liste des salons
- [ ] Vérifier que les options "Favoris", "Notifications" et "Quitter" fonctionnent (Quitter ne devrait pas empêcher de recevoir le prochain message)

![Simulator Screenshot - iPhone 15 - 2024-04-04 at 15 12 34](https://github.com/tchapgouv/tchap-ios/assets/18608158/fa782b68-f3a8-4944-a4a1-79f5b6488471)