### PR TITLE
Mauvais libellé de fermeture de compte en anglais

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -860,7 +860,7 @@ Tap the + to start adding people.";
 "settings_crypto_export" = "Export keys";
 "settings_crypto_blacklist_unverified_devices" = "Encrypt to verified sessions only";
 
-"settings_deactivate_my_account" = "Close account permanently"; // Tchap
+"settings_deactivate_my_account" = "Close account"; // Tchap
 
 "settings_key_backup_info" = "Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.";
 "settings_key_backup_info_checking" = "Checking…";

--- a/changelog.d/1019.change
+++ b/changelog.d/1019.change
@@ -1,0 +1,1 @@
+Mauvais libellé de fermeture de compte en anglais.


### PR DESCRIPTION
Fix #1019 

Before :
![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/ec18c97c-893b-4e66-87ce-7cf3af0abe4e)

After : 
![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/79631b36-95dc-4107-959e-4ab32ec332ae)
