### PR TITLE
Invitations : forcer l'email en minuscules à l'envoi d'invitation

### DIFF
--- a/Riot/Modules/Room/ParticipantsInviteModal/ContactsPicker/ContactsPickerViewModel.swift
+++ b/Riot/Modules/Room/ParticipantsInviteModal/ContactsPicker/ContactsPickerViewModel.swift
@@ -128,6 +128,9 @@ class ContactsPickerViewModel: NSObject, ContactsPickerViewModelProtocol {
         contactsViewController.showSearch(true)
         // Tchap: Replace string by removing user ID
         contactsViewController.searchBar.placeholder = VectorL10n.roomParticipantsInviteAnotherUserWithoutId
+        // Tchap: don't force capitalization of first char of search input (to protect capitalization of email)
+        // when inviting a participant in a room.
+        contactsViewController.searchBar.searchTextField.autocapitalizationType = .none
         // Tchap: don't make searchbar resign as first responder.
         // Let it becomes first responder to activate the input field and deploy the keyboard when the controller comes to screen.
 //        contactsViewController.searchBar.resignFirstResponder()
@@ -279,7 +282,9 @@ extension ContactsPickerViewModel: ContactsTableViewControllerDelegate {
             self.coordinatorDelegate?.contactsPickerViewModelDidStartInvite(self)
             // Is it an email or a Matrix user ID?
             if MXTools.isEmailAddress(participantId) {
-                room.invite(.email(participantId)) { [weak self] response in
+                // Tchap: be sure to convert email address to lowercase.
+//                room.invite(.email(participantId)) { [weak self] response in
+                room.invite(.email(participantId.lowercased())) { [weak self] response in
                     guard let self = self else { return }
                     
                     switch response {

--- a/Riot/Modules/StartChat/StartChatViewController.m
+++ b/Riot/Modules/StartChat/StartChatViewController.m
@@ -708,7 +708,9 @@
                     MXInvite3PID *invite3PID = [[MXInvite3PID alloc] init];
                     invite3PID.identityServer = identityServer;
                     invite3PID.medium = kMX3PIDMediumEmail;
-                    invite3PID.address = participantId;
+                    // Tchap: be sure to convert email address to lowercase
+//                    invite3PID.address = participantId;
+                    invite3PID.address = participantId.lowercaseString;
                     
                     [invite3PIDArray addObject:invite3PID];
                 }

--- a/changelog.d/1024.change
+++ b/changelog.d/1024.change
@@ -1,0 +1,1 @@
+forcer l'email en minuscules à l'envoi d'invitation à un salon (pour éviter les problèmes d'email avec majuscules)


### PR DESCRIPTION
Fix #1024 

![Simulator Screenshot - iPhone 15 - 2024-05-06 at 18 34 47](https://github.com/tchapgouv/tchap-ios/assets/18608158/fd3261b0-7d1b-4f92-9fe1-235b1cf348a8)
