### PR TITLE
Ouverture de la fonctionnalité VoIP à toutes les instances

### DIFF
--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -273,9 +273,7 @@ final class BuildSettings: NSObject {
             tchapFeatureAnyHomeServer
         ],
         tchapFeatureVoiceOverIP: [
-            "agent.dinum.tchap.gouv.fr",
-            "agent.diplomatie.tchap.gouv.fr",
-            "agent.finances.tchap.gouv.fr"
+            tchapFeatureAnyHomeServer
         ],
         // No activation of video calls actually in Tchap Production.
 //        tchapFeatureVideoOverIP: [

--- a/changelog.d/1036.change
+++ b/changelog.d/1036.change
@@ -1,0 +1,1 @@
+Ouverture de la fonctionnalité VoIP à toutes les instances.


### PR DESCRIPTION
Fix #1036 

La fonctionnalité VoIP est ouverte sans restriction d'instance :
```
        tchapFeatureVoiceOverIP: [
            tchapFeatureAnyHomeServer
        ]
```