### PR TITLE
Changement du copyright de fournisseur de fond de carte de géolocalis…

### DIFF
--- a/Riot/Modules/Room/TimelineCells/LocationView/RoomTimelineLocationView.xib
+++ b/Riot/Modules/Room/TimelineCells/LocationView/RoomTimelineLocationView.xib
@@ -86,7 +86,7 @@ This homeserver is not configured to display maps</string>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HzR-Av-TiG">
                             <rect key="frame" x="0.0" y="0.0" width="395" height="20"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="©MapTiler ©OpenStreetMap contributors" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jWW-0w-1YM">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="© Etalab © OpenMapTiles © Contributeurs OpenStreetMap" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jWW-0w-1YM">
                                     <rect key="frame" x="8" y="0.0" width="379" height="20"/>
                                     <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="10"/>

--- a/RiotSwiftUI/Modules/LocationSharing/MapCredits/MapCreditsActionSheet.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/MapCredits/MapCreditsActionSheet.swift
@@ -24,11 +24,14 @@ struct MapCreditsActionSheet {
     var sheet: ActionSheet {
         ActionSheet(title: Text(VectorL10n.locationSharingMapCreditsTitle),
                     buttons: [
-                        .default(Text("© MapTiler")) {
-                            openURL(URL(string: "https://www.maptiler.com/copyright/")!)
+                        .default(Text("© Etalab")) {
+                            openURL(URL(string: "https://www.etalab.gouv.fr/")!)
+                        },
+                        .default(Text("© OpenMapTiles")) {
+                            openURL(URL(string: "https://www.openmaptiles.org/")!)
                         },
                         .default(Text("© OpenStreetMap")) {
-                            openURL(URL(string: "https://www.openstreetmap.org/copyright")!)
+                            openURL(URL(string: "https://www.openstreetmap.org/copyright/")!)
                         },
                         .cancel()
                     ])

--- a/changelog.d/1039.change
+++ b/changelog.d/1039.change
@@ -1,0 +1,1 @@
+Changement du copyright de fournisseur de fond de carte de géolocalisation


### PR DESCRIPTION
Fix #1039 

Les copyrights corrigés :
![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/02dda29b-0bcd-4098-b460-5ea33ac85e22)

Les liens corrigés :
![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/4295c1dd-27ba-48c1-955b-0590d7c0362d)
