### PR TITLE
Ajout de la licence MapLibre dans les licences tierces

### DIFF
--- a/Riot/Assets/third_party_licenses.html
+++ b/Riot/Assets/third_party_licenses.html
@@ -1965,18 +1965,6 @@
         POSSIBILITY OF SUCH DAMAGE.
         <br/><br/>
     </li>
-
-    
-    
-    
-    
-    
-    
-
-
-
-
-
 </ul>
 </body>
 </html>

--- a/Riot/Assets/third_party_licenses.html
+++ b/Riot/Assets/third_party_licenses.html
@@ -1934,6 +1934,49 @@
         THE SOFTWARE.
         <br/><br/>
     </li>
+    <li>
+        <b>MapLibre</b> (<a href="https://github.com/maptiler/maplibre-gl-native">https://github.com/maptiler/maplibre-gl-native</a>)
+        <br/><br/>
+        BSD 2-Clause License
+        <br/><br/>
+        Copyright (c) 2021 MapLibre contributors
+        <br/>
+        Copyright (c) 2018-2021 MapTiler.com
+        <br/>
+        Copyright (c) 2014-2020 Mapbox
+        <br/><br/>
+        Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+        <br/>
+        <ul>
+            <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+            <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
+        </ul>
+        <br/><br/>
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+        ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+        LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+        CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+        POSSIBILITY OF SUCH DAMAGE.
+        <br/><br/>
+    </li>
+
+    
+    
+    
+    
+    
+    
+
+
+
+
+
 </ul>
 </body>
 </html>

--- a/changelog.d/1041.change
+++ b/changelog.d/1041.change
@@ -1,0 +1,1 @@
+Ajout de la licence MapLibre dans les licences tierces


### PR DESCRIPTION
Fix #1041 

![image](https://github.com/tchapgouv/tchap-ios/assets/18608158/30c098fe-55de-4430-a765-24f17b2c505f)
