### PR TITLE
Activate Video VoIP 1-to-1 for Education Nationale

### DIFF
--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -293,7 +293,8 @@ final class BuildSettings: NSObject {
             "agent.education.tchap.gouv.fr"
         ],
         tchapFeatureVideoOverIP: [
-            "agent.dinum.tchap.gouv.fr"
+            "agent.dinum.tchap.gouv.fr",
+            "agent.education.tchap.gouv.fr"
         ],
         tchapFeatureGeolocationSharing: [
             tchapFeatureAnyHomeServer

--- a/changelog.d/1090.change
+++ b/changelog.d/1090.change
@@ -1,0 +1,1 @@
+Activation de la visio 1-to-1 pour l'instance Education Nationale


### PR DESCRIPTION
Fix #1090

Testé sur :
- [x] Justice : l'icone de camera n'apparaît pas en Messages Directs
- [x] Education nationale : l'icône de caméra apparaiit en Messages Directs