### PR TITLE
Tchap échoue à la compilation avec Xcode 16.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ abstract_target 'TchapPods' do
 
   # PostHog for analytics
   pod 'PostHog', '~> 2.0.0'
-  pod 'Sentry', '~> 7.15.0'
+  pod 'Sentry', '~> 8.40.1'
 
   pod 'RxSwift', '~> 5.1.1'
 

--- a/changelog.d/1118.change
+++ b/changelog.d/1118.change
@@ -1,0 +1,1 @@
+Update Sentry pod dependency to compile with Xcode 16.1


### PR DESCRIPTION
Fix #1118 

Set Sentry Pod dependency from 7.35.1 to 8.40.1.