### PR TITLE
Ajouter la configuration posthog pour vérifier la charge en production

### DIFF
--- a/Riot/Modules/Room/RoomDisplayConfiguration.swift
+++ b/Riot/Modules/Room/RoomDisplayConfiguration.swift
@@ -18,7 +18,7 @@ class RoomDisplayConfiguration: NSObject {
         guard _tchapCallsEnabled,
               let account = MXKAccountManager.shared().activeAccounts.first
         else { return false }
-        // Tchap: actually, only allow VoIP for DINUM homeServer.
+        // Tchap: actually, only allow VoIP by homeServer.
         if (account.isFeatureActivated(BuildSettings.tchapFeatureVoiceOverIP) || account.isFeatureActivated(BuildSettings.tchapFeatureVideoOverIP)) {
             return true
         }

--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -209,12 +209,12 @@ final class BuildSettings: NSObject {
                                                                termsURL: URL(string: "https://tchap.beta.gouv.fr/politique-de-confidentialite")!) // Tchap: dev posthog,
     #else
     /// The configuration to use for analytics. Set `isEnabled` to false to disable analytics.
-    static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: false,
-                                                               host: "",
-                                                               apiKey: "",
-                                                               termsURL: URL(string: "https://")!)
+    static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: true, // Tchap: enable PostHog analytics on production
+                                                               host: "https://posthogdev.tchap.incubateur.net", // Tchap: prod posthog,
+                                                               apiKey: "phc_FFa4pkvmuWjF9nZOMmYJWUXMibuYnCnPyf3DqPGZs4L", // Tchap: prod posthog,
+                                                               termsURL: URL(string: "https://tchap.beta.gouv.fr/politique-de-confidentialite")!)
     #endif
-    
+
     // MARK: - Bug report
     static let bugReportEndpointUrlString = ""
     static let bugReportDefaultHost = "agent.tchap.gouv.fr"

--- a/changelog.d/1135.change
+++ b/changelog.d/1135.change
@@ -1,0 +1,1 @@
+Ajouter la configuration posthog pour vérifier la charge en production


### PR DESCRIPTION
Fix #1135 

Les events iOS Prod remontent bien jusqu'à PostHog : 

<img width="1210" alt="Screenshot 2024-12-11 at 16 02 10" src="https://github.com/user-attachments/assets/55d840b3-2a4d-4829-b088-acd8109905f3" />
