### PR TITLE
Update TAC and private policy URLs

### DIFF
--- a/Btchap/Config/BuildSettings.swift
+++ b/Btchap/Config/BuildSettings.swift
@@ -118,7 +118,7 @@ final class BuildSettings: NSObject {
     // MARK: - Legal URLs
  
     // Note: Set empty strings to hide the related entry in application settings
-    static let applicationTermsConditionsUrlString = "https://www.tchap.gouv.fr/tac.html"
+    static let applicationTermsConditionsUrlString = "https://tchap.numerique.gouv.fr/cgu" // Tchap: redirect to CGU
     static let clientConfigURL = "https://www.tchap.gouv.fr/client/config/preprod/ios"
     static let applicationHelpUrlString = "https://www.beta.tchap.gouv.fr/faq"
     static let applicationServicesStatusUrlString = "https://status.tchap.numerique.gouv.fr/"
@@ -177,7 +177,7 @@ final class BuildSettings: NSObject {
     static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: true, // Tchap: enable PostHog analytics on DEBUG
                                                                host: "https://us.i.posthog.com", // Tchap: dev posthog,
                                                                apiKey: "phc_eQOeaQiaIxdX9kaQmqYTD7RJLyFubYmGYKUI9czqqQD", // Tchap: dev posthog,
-                                                               termsURL: URL(string: "https://tchap.beta.gouv.fr/politique-de-confidentialite")!) // Tchap: dev posthog,
+                                                               termsURL: URL(string: "https://tchap.numerique.gouv.fr/politique-de-confidentialite")!) // Tchap: dev posthog,
     #else
     /// The configuration to use for analytics. Set `isEnabled` to false to disable analytics.
     static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: false,

--- a/DevTchap/Config/BuildSettings.swift
+++ b/DevTchap/Config/BuildSettings.swift
@@ -118,7 +118,7 @@ final class BuildSettings: NSObject {
     // MARK: - Legal URLs
 
     // Note: Set empty strings to hide the related entry in application settings
-    static let applicationTermsConditionsUrlString = "https://www.tchap.incubateur.net/tac.html"
+    static let applicationTermsConditionsUrlString = "https://tchap.numerique.gouv.fr/cgu" // Tchap: redirect to CGU
     static let clientConfigURL = "https://www.tchap.incubateur.net/client/config/agent/ios"
     static let applicationHelpUrlString = "https://www.tchap.incubateur.net/faq"
     static let applicationServicesStatusUrlString = "https://status.tchap.numerique.gouv.fr/"
@@ -177,7 +177,7 @@ final class BuildSettings: NSObject {
     static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: true, // Tchap: enable PostHog analytics on DEBUG
                                                                host: "https://us.i.posthog.com", // Tchap: dev posthog,
                                                                apiKey: "phc_eQOeaQiaIxdX9kaQmqYTD7RJLyFubYmGYKUI9czqqQD", // Tchap: dev posthog,
-                                                               termsURL: URL(string: "https://tchap.beta.gouv.fr/politique-de-confidentialite")!) // Tchap: dev posthog,
+                                                               termsURL: URL(string: "https://tchap.numerique.gouv.fr/politique-de-confidentialite")!) // Tchap: dev posthog,
     #else
     /// The configuration to use for analytics. Set `isEnabled` to false to disable analytics.
     static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: false,

--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -132,7 +132,7 @@ final class BuildSettings: NSObject {
     // MARK: - Legal URLs
 
     // Note: Set empty strings to hide the related entry in application settings
-    static let applicationTermsConditionsUrlString = "https://www.tchap.gouv.fr/tac.html"
+    static let applicationTermsConditionsUrlString = "https://tchap.numerique.gouv.fr/cgu" // Tchap: redirect to CGU
     static let clientConfigURL = "https://www.tchap.gouv.fr/client/config/agent/ios"
     static let applicationHelpUrlString = "https://www.tchap.gouv.fr/faq"
     static let applicationServicesStatusUrlString = "https://status.tchap.numerique.gouv.fr/"
@@ -206,13 +206,13 @@ final class BuildSettings: NSObject {
     static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: true, // Tchap: enable PostHog analytics on DEBUG
                                                                host: "https://us.i.posthog.com", // Tchap: dev posthog,
                                                                apiKey: "phc_eQOeaQiaIxdX9kaQmqYTD7RJLyFubYmGYKUI9czqqQD", // Tchap: dev posthog,
-                                                               termsURL: URL(string: "https://tchap.beta.gouv.fr/politique-de-confidentialite")!) // Tchap: dev posthog,
+                                                               termsURL: URL(string: "https://tchap.numerique.gouv.fr/politique-de-confidentialite")!) // Tchap: dev posthog,
     #else
     /// The configuration to use for analytics. Set `isEnabled` to false to disable analytics.
     static let analyticsConfiguration = AnalyticsConfiguration(isEnabled: true, // Tchap: enable PostHog analytics on production
                                                                host: "https://posthogdev.tchap.incubateur.net", // Tchap: prod posthog,
                                                                apiKey: "phc_FFa4pkvmuWjF9nZOMmYJWUXMibuYnCnPyf3DqPGZs4L", // Tchap: prod posthog,
-                                                               termsURL: URL(string: "https://tchap.beta.gouv.fr/politique-de-confidentialite")!)
+                                                               termsURL: URL(string: "https://tchap.numerique.gouv.fr/politique-de-confidentialite")!)
     #endif
 
     // MARK: - Bug report

--- a/changelog.d/1141.change
+++ b/changelog.d/1141.change
@@ -1,0 +1,1 @@
+Update TAC and private policy URLs


### PR DESCRIPTION
Fix #1141  

Pensez à mettre à jour les liens d'articles de FAQ suivant quand la migration de domaine sera finalisée : 
- https://aide.tchap.beta.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y/
- https://aide.tchap.beta.gouv.fr/fr/article/notification-par-email-draft-6k7k89/
- https://aide.tchap.beta.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1