### PR TITLE
Réactiver l'affichage des albums dans le sélecteur de media sous iOS 18

### DIFF
--- a/Riot/Modules/MediaPicker/MediaPickerViewController.m
+++ b/Riot/Modules/MediaPicker/MediaPickerViewController.m
@@ -392,8 +392,11 @@ Please see LICENSE in the repository root for full details.
         MXStrongifyAndReturnIfNil(self);
         
         // List user albums which are not empty
-        PHFetchResult *albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAlbumRegular options:nil];
-        
+        // Tchap: starting from iOS 18, select any subtype albums rather than regular ones else no album is listed (only a few recents photos)
+        //        Maybe because 'smart' albums get a full revamp in iOS 18?
+//        PHFetchResult *albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAlbumRegular options:nil];
+        PHFetchResult *albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAny options:nil];
+
         NSMutableArray *updatedUserAlbums = [NSMutableArray array];
         __block PHAssetCollection *cameraRollAlbum, *videoAlbum;
         

--- a/changelog.d/1143.bugfix
+++ b/changelog.d/1143.bugfix
@@ -1,0 +1,1 @@
+Réactiver l'affichage des albums dans le sélecteur de media sous iOS 18.


### PR DESCRIPTION
Fix #1143

Pushed to Element: https://github.com/element-hq/element-ios/pull/7888