### PR TITLE
1160 changer le message dans tchap ios sur la contrainte de 12 caracteres minimum sur le mdp au lieu de 8

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -150,7 +150,7 @@
 "authentication_registration_username_footer" = "You can’t change this later";
 /* The placeholder will show the full Matrix ID that has been entered. */
 "authentication_registration_username_footer_available" = "Others can discover you %@";
-"authentication_registration_password_footer" = "Must be 8 characters or more";
+"authentication_registration_password_footer" = "Must be 12 characters or more"; // Tchap
 "authentication_server_info_title" = "Where your conversations will live";
 
 "authentication_login_title" = "Welcome back!";
@@ -188,7 +188,7 @@
 "authentication_forgot_password_waiting_button" = "Resend email";
 
 "authentication_choose_password_input_title" = "Choose a new password";
-"authentication_choose_password_input_message" = "Make sure it’s 8 characters or more";
+"authentication_choose_password_input_message" = "Make sure it’s 12 characters or more"; // Tchap
 "authentication_choose_password_text_field_placeholder" = "New Password";
 "authentication_choose_password_signout_all_devices" = "Sign out of all devices";
 "authentication_choose_password_submit_button" = "Reset Password";
@@ -259,7 +259,7 @@
 
 // MARK: Password policy errors
 "password_policy_too_short_pwd_error" = "Too short password";
-"password_policy_weak_pwd_error" = "This password is too weak. It must contain at least 8 characters, with at least one character of each type: uppercase, lowercase, digit and special character.";
+"password_policy_weak_pwd_error" = "This password is too weak. It must contain at least 12 characters, with at least one character of each type: uppercase, lowercase, digit and special character."; // Tchap
 "password_policy_pwd_in_dict_error" = "This password has been found in a dictionary, and is not allowed.";
 
 // MARK: Legacy Authentication

--- a/Riot/Assets/fr.lproj/Vector.strings
+++ b/Riot/Assets/fr.lproj/Vector.strings
@@ -2285,7 +2285,7 @@
 "authentication_choose_password_submit_button" = "Réinitialiser le mot de passe";
 "authentication_choose_password_signout_all_devices" = "Déconnecter tous les appareils";
 "authentication_choose_password_text_field_placeholder" = "Nouveau mot de passe";
-"authentication_choose_password_input_message" = "Assurez-vous qu’il fait 8 caractères ou plus";
+"authentication_choose_password_input_message" = "Assurez-vous qu’il fait 12 caractères ou plus"; // Tchap
 "authentication_choose_password_input_title" = "Choisissez un nouveau mot de passe";
 "authentication_forgot_password_waiting_button" = "Renvoyer l’email";
 /* The placeholder will show the email address that was entered. */
@@ -2317,7 +2317,7 @@
 "authentication_server_info_title" = "Où seront vous conversations";
 /* The placeholder will show the full Matrix ID that has been entered. */
 "authentication_registration_username_footer_available" = "Les autres peuvent vous trouver %@";
-"authentication_registration_password_footer" = "Le mot de passe doit contenir au moins 8 caractères";
+"authentication_registration_password_footer" = "Le mot de passe doit contenir au moins 12 caractères"; // Tchap
 "authentication_registration_username_footer" = "Vous ne pourrez pas le changer par la suite";
 "authentication_registration_username" = "Nom d'utilisateur.ice";
 
@@ -2767,7 +2767,7 @@
 "settings_labs_enable_crypto_sdk" = "Chiffrement de bout en bout en Rust";
 "settings_push_rules_error" = "Nous avons rencontré une erreur lors de la mise à jours de vos préférences de notification. Veuillez réactiver l'option.";
 "password_policy_pwd_in_dict_error" = "Ce mot de passe a été trouvé dans un dictionnaire, et son usage n'est donc pas autorisé.";
-"password_policy_weak_pwd_error" = "Ce mot de passe est trop faible. Il doit contenir au moins 8 caractères, dont au moins une majuscule, une minuscule, un chiffre et un caractère spécial.";
+"password_policy_weak_pwd_error" = "Ce mot de passe est trop faible. Il doit contenir au moins 12 caractères, dont au moins une majuscule, une minuscule, un chiffre et un caractère spécial."; // Tchap
 
 // MARK: Password policy errors
 "password_policy_too_short_pwd_error" = "Mot de passe trop court";

--- a/Riot/Categories/MXError.swift
+++ b/Riot/Categories/MXError.swift
@@ -31,13 +31,13 @@ extension MXError {
         case kMXErrCodeStringPasswordTooShort:
             message = TchapL10n.passwordPolicyTooShortPwdError // Tchap
         case kMXErrCodeStringPasswordNoDigit:
-            message = TchapL10n.passwordPolicyWeakPwdError // Tchap
+            message = TchapL10n.registrationErrorPasswordPolicyErrorNoDigit // Tchap: password policy
         case kMXErrCodeStringPasswordNoLowercase:
-            message = TchapL10n.passwordPolicyWeakPwdError // Tchap
+            message = TchapL10n.registrationErrorPasswordPolicyErrorNoLowercase // Tchap: password policy
         case kMXErrCodeStringPasswordNoUppercase:
-            message = TchapL10n.passwordPolicyWeakPwdError // Tchap
+            message = TchapL10n.registrationErrorPasswordPolicyErrorNoUppercase // Tchap: password policy
         case kMXErrCodeStringPasswordNoSymbol:
-            message = TchapL10n.passwordPolicyWeakPwdError // Tchap
+            message = TchapL10n.registrationErrorPasswordPolicyErrorNoSymbol // Tchap: password policy
         case kMXErrCodeStringWeakPassword:
             message = TchapL10n.passwordPolicyWeakPwdError // Tchap
         case kMXErrCodeStringPasswordInDictionary:

--- a/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationModels.swift
@@ -100,9 +100,9 @@ struct AuthenticationRegistrationViewState: BindableState {
     
     /// Whether the current `password` is invalid.
     var isPasswordInvalid: Bool {
-        // Tchap: raise the password min length to 12
+        // Tchap: password policy
 //        bindings.password.count < 8
-        bindings.password.count < 12
+        bindings.password.count < FormRules.passwordMinLength
     }
     
     /// `true` if it is possible to continue, otherwise `false`.

--- a/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/AuthenticationRegistrationModels.swift
@@ -100,7 +100,9 @@ struct AuthenticationRegistrationViewState: BindableState {
     
     /// Whether the current `password` is invalid.
     var isPasswordInvalid: Bool {
-        bindings.password.count < 8
+        // Tchap: raise the password min length to 12
+//        bindings.password.count < 8
+        bindings.password.count < 12
     }
     
     /// `true` if it is possible to continue, otherwise `false`.

--- a/RiotSwiftUI/Modules/Authentication/VerifyEmail/AuthenticationVerifyEmailModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/VerifyEmail/AuthenticationVerifyEmailModels.swift
@@ -54,7 +54,9 @@ struct AuthenticationVerifyEmailViewState: BindableState {
     
     /// Whether the current `password` is invalid.
     var isPasswordInvalid: Bool {
-        bindings.password.count < 8
+        // Tchap: raise the password min length to 12
+//        bindings.password.count < 8
+        bindings.password.count < 12
     }
     
     /// `true` if it is possible to continue, otherwise `false`.

--- a/RiotSwiftUI/Modules/Authentication/VerifyEmail/AuthenticationVerifyEmailModels.swift
+++ b/RiotSwiftUI/Modules/Authentication/VerifyEmail/AuthenticationVerifyEmailModels.swift
@@ -54,9 +54,9 @@ struct AuthenticationVerifyEmailViewState: BindableState {
     
     /// Whether the current `password` is invalid.
     var isPasswordInvalid: Bool {
-        // Tchap: raise the password min length to 12
+        // Tchap: password policy
 //        bindings.password.count < 8
-        bindings.password.count < 12
+        bindings.password.count < FormRules.passwordMinLength
     }
     
     /// `true` if it is possible to continue, otherwise `false`.

--- a/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
+++ b/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
@@ -68,7 +68,7 @@
 "registration_mail_placeholder" = "Adresse email";
 "registration_mail_additional_info" = "Utilisez votre adresse professionnelle";
 "registration_password_placeholder" = "Mot de passe Tchap";
-"registration_password_additional_info" = "Votre mot de passe doit contenir au moins 8 caractères, avec au moins un caractère de chaque type\U00A0:\U00A0majuscule, minuscule, chiffre, caractère spécial";
+"registration_password_additional_info" = "Votre mot de passe doit contenir au moins 12 caractères, avec au moins un caractère de chaque type\U00A0:\U00A0majuscule, minuscule, chiffre, caractère spécial";
 "registration_confirm_password_placeholder" = "Confirmer le mot de passe";
 
 "registration_warning_for_external_user_title" = "Information concernant votre inscription";
@@ -92,7 +92,7 @@
 
 "password_policy_too_short_pwd_error" = "Mot de passe trop court";
 "password_policy_too_short_pwd_detailed_error" = "Mot de passe trop court (min %d)";
-"password_policy_weak_pwd_error" = "Ce mot de passe est trop faible. Il doit contenir au moins 8 caractères, avec au moins un caractère de chaque type\U00A0:\U00A0majuscule, minuscule, chiffre, caractère spécial";
+"password_policy_weak_pwd_error" = "Ce mot de passe est trop faible. Il doit contenir au moins 12 caractères, avec au moins un caractère de chaque type\U00A0:\U00A0majuscule, minuscule, chiffre, caractère spécial";
 "password_policy_pwd_in_dict_error" = "Ce mot de passe a été trouvé dans un dictionnaire, il n’est pas autorisé";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -272,7 +272,7 @@
 "change_password_current_password_validate_action" = "Valider";
 // New password
 "change_password_new_password_title" = "Nouveau mot de passe";
-"change_password_new_password_instructions" = "Votre nouveau mot de passe doit contenir au moins 8 caractères, avec au moins un caractère de chaque type\U00A0:\U00A0majuscule, minuscule, chiffre, caractère spécial.";
+"change_password_new_password_instructions" = "Votre nouveau mot de passe doit contenir au moins 12 caractères, avec au moins un caractère de chaque type\U00A0:\U00A0majuscule, minuscule, chiffre, caractère spécial.";
 "change_password_new_password_password_placeholder" = "Nouveau mot de passe";
 "change_password_new_password_confirm_password_placeholder" = "Confirmez votre nouveau mot de passe";
 "change_password_new_password_validate_action" = "Valider";

--- a/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
+++ b/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
@@ -82,6 +82,10 @@
 
 "registration_error_unchecked_terms" = "Vous devez accepter les Conditions Générales d'Utilisation";
 "registration_error_passwords_dont_match" = "Les mots de passe ne correspondent pas";
+"registration_error_password_policy_error_no_digit" = "Le mot de passe doit comporter au moins 1 chiffre.";
+"registration_error_password_policy_error_no_lowercase" = "Le mot de passe doit comporter au moins 1 lettre minuscule.";
+"registration_error_password_policy_error_no_uppercase" = "Le mot de passe doit comporter au moins 1 lettre majuscule.";
+"registration_error_password_policy_error_no_symbol" = "Le mot de passe doit comporter au moins 1 symbole.";
 
 "registration_email_sent_info" = "Un email vous a été envoyé à l'adresse suivante, sauf si un compte Tchap lui a déjà été associé\U00A0:\U00A0";
 "registration_email_sent_instructions" = "Merci de cliquer sur le lien proposé dans cet email afin de terminer la création de votre compte. Vous pourrez alors vous connecter en allant sur l'écran de connexion.";
@@ -91,7 +95,7 @@
 "registration_email_validation_failed_msg" = "Le lien a expiré, ou il n'est pas valide";
 
 "password_policy_too_short_pwd_error" = "Mot de passe trop court";
-"password_policy_too_short_pwd_detailed_error" = "Mot de passe trop court (min %d)";
+"password_policy_too_short_pwd_detailed_error" = "Votre mot de passe est trop court. Il doit comporter au moins %d caractères."; // Tchap: password policy
 "password_policy_weak_pwd_error" = "Ce mot de passe est trop faible. Il doit contenir au moins 12 caractères, avec au moins un caractère de chaque type\U00A0:\U00A0majuscule, minuscule, chiffre, caractère spécial";
 "password_policy_pwd_in_dict_error" = "Ce mot de passe a été trouvé dans un dictionnaire, il n’est pas autorisé";
 

--- a/Tchap/Modules/ChangePassword/NewPassword/ChangePasswordNewPasswordViewController.swift
+++ b/Tchap/Modules/ChangePassword/NewPassword/ChangePasswordNewPasswordViewController.swift
@@ -179,6 +179,15 @@ final class ChangePasswordNewPasswordViewController: UIViewController {
                 errorMessage = TchapL10n.passwordPolicyTooShortPwdDetailedError(FormRules.passwordMinLength)
             case .invalidPassword:
                 errorMessage = TchapL10n.registrationPasswordAdditionalInfo
+            // Tchap: password policy
+            case .passwordPolicyNoDigit:
+                errorMessage = TchapL10n.registrationErrorPasswordPolicyErrorNoDigit
+            case .passwordPolicyNoUppercase:
+                errorMessage = TchapL10n.registrationErrorPasswordPolicyErrorNoUppercase
+            case .passwordPolicyNoLowercase:
+                errorMessage = TchapL10n.registrationErrorPasswordPolicyErrorNoLowercase
+            case .passwordPolicyNoSymbol:
+                errorMessage = TchapL10n.registrationErrorPasswordPolicyErrorNoSymbol
             }
         } else {
             let builder = MXKErrorPresentableBuilder()

--- a/Tchap/Modules/ChangePassword/NewPassword/ChangePasswordNewPasswordViewModel.swift
+++ b/Tchap/Modules/ChangePassword/NewPassword/ChangePasswordNewPasswordViewModel.swift
@@ -165,8 +165,17 @@ final class ChangePasswordNewPasswordViewModel: ChangePasswordNewPasswordViewMod
                             passwordError = .invalidOldPassword
                         case kMXErrCodeStringPasswordTooShort:
                             passwordError = .passwordTooShort
-                        case kMXErrCodeStringPasswordNoDigit, kMXErrCodeStringPasswordNoUppercase, kMXErrCodeStringPasswordNoLowercase, kMXErrCodeStringPasswordNoSymbol:
-                            passwordError = .invalidPassword
+                        // Tchap: password policy
+//                        case kMXErrCodeStringPasswordNoDigit, kMXErrCodeStringPasswordNoUppercase, kMXErrCodeStringPasswordNoLowercase, kMXErrCodeStringPasswordNoSymbol:
+//                            passwordError = .invalidPassword
+                        case kMXErrCodeStringPasswordNoDigit:
+                            passwordError = .passwordPolicyNoDigit
+                        case kMXErrCodeStringPasswordNoUppercase:
+                            passwordError = .passwordPolicyNoUppercase
+                        case kMXErrCodeStringPasswordNoLowercase:
+                            passwordError = .passwordPolicyNoLowercase
+                        case kMXErrCodeStringPasswordNoSymbol:
+                            passwordError = .passwordPolicyNoSymbol
                         default:
                             passwordError = nil
                         }

--- a/Tchap/Modules/ChangePassword/NewPassword/ChangePasswordNewPasswordViewModelType.swift
+++ b/Tchap/Modules/ChangePassword/NewPassword/ChangePasswordNewPasswordViewModelType.swift
@@ -32,6 +32,11 @@ enum ChangePasswordNewPasswordViewModelError: Error {
     case invalidPassword
     case passwordsDontMatch
     case invalidOldPassword
+    // Tchap: password policy
+    case passwordPolicyNoDigit
+    case passwordPolicyNoUppercase
+    case passwordPolicyNoLowercase
+    case passwordPolicyNoSymbol
 }
 
 /// Protocol describing the view model used by `ChangePasswordNewPasswordViewController`

--- a/changelog.d/1160.change
+++ b/changelog.d/1160.change
@@ -1,0 +1,1 @@
+Gérer correctement les erreurs retournées par le backend à la création ou changement du mot de passe.


### PR DESCRIPTION
Fix #1160 

Respect du password policy du backend à la création de compte : 
![Simulator Screenshot - iPhone 16 - 2025-04-10 at 15 43 15](https://github.com/user-attachments/assets/54e5135e-5708-4e15-8b52-ab50621f4f0e)

Respect du password policy du backend au changement de password du compte : 
![Simulator Screenshot - iPhone 16 - 2025-04-10 at 15 30 17](https://github.com/user-attachments/assets/451e1782-8551-4f46-8cbb-20fc1a6584ed)
