### PR TITLE
Remplacer les URL de FAQ encore en "tchap.beta.gouv.fr"

### DIFF
--- a/Btchap/Config/BuildSettings.swift
+++ b/Btchap/Config/BuildSettings.swift
@@ -124,11 +124,11 @@ final class BuildSettings: NSObject {
     static let applicationServicesStatusUrlString = "https://status.tchap.numerique.gouv.fr/"
     static let applicationAcceptableUsePolicyUrlString = ""
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
-    static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
-    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
-    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
-    static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
+    static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
+    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
+    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
+    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
+    static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 
     // MARK: - Matrix permalinks
     // Hosts/Paths for URLs that will considered as valid permalinks. Those permalinks are opened within the app.

--- a/DevTchap/Config/BuildSettings.swift
+++ b/DevTchap/Config/BuildSettings.swift
@@ -124,11 +124,11 @@ final class BuildSettings: NSObject {
     static let applicationServicesStatusUrlString = "https://status.tchap.numerique.gouv.fr/"
     static let applicationAcceptableUsePolicyUrlString = ""
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
-    static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
-    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
-    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
-    static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
+    static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
+    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
+    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
+    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
+    static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 
     // MARK: - Matrix permalinks
     // Hosts/Paths for URLs that will considered as valid permalinks. Those permalinks are opened within the app.

--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -138,11 +138,11 @@ final class BuildSettings: NSObject {
     static let applicationServicesStatusUrlString = "https://status.tchap.numerique.gouv.fr/"
     static let applicationAcceptableUsePolicyUrlString = ""
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
-    static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
-    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
-    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
-    static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.beta.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
+    static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
+    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
+    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
+    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
+    static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
     
     // MARK: - Matrix permalinks
     // Hosts/Paths for URLs that will considered as valid permalinks. Those permalinks are opened within the app.

--- a/changelog.d/1186.change
+++ b/changelog.d/1186.change
@@ -1,0 +1,1 @@
+Remplacer les URL de FAQ encore en "tchap.beta.gouv.fr"


### PR DESCRIPTION
Fix #1186