### PR TITLE
Changer le wording des sections liées à la sécurité et au chiffrement

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -930,7 +930,7 @@ Tap the + to start adding people.";
 "settings_presence_offline_mode_description" = "If enabled, you will always appear offline to other users, even when using the application.";
 
 // Security settings
-"security_settings_title" = "Security";
+"security_settings_title" = "Encrypted messages and devices"; // Tchap
 "security_settings_crypto_sessions" = "CONNECTED DEVICES"; // Tchap
 "security_settings_crypto_sessions_loading" = "Loading sessions…";
 "security_settings_crypto_sessions_description_2" = "If you don’t recognise a login, change your Matrix account password and reset Secure Backup.";

--- a/Riot/Assets/fr.lproj/Vector.strings
+++ b/Riot/Assets/fr.lproj/Vector.strings
@@ -963,7 +963,7 @@
 "settings_labs_enable_cross_signing" = "Activer la vérification croisée pour vérifier par utilisateurs plutôt que par appareil (en développement)";
 "settings_security" = "SÉCURITÉ";
 // Security settings
-"security_settings_title" = "Sécurité";
+"security_settings_title" = "Messages chiffrés et appareils"; // Tchap
 "security_settings_crypto_sessions" = "APPAREILS CONNECTÉS"; // Tchap
 "security_settings_crypto_sessions_description" = "Faites confiance à des sessions pour leur accorder l’accès aux messages chiffrés de bout en bout. Si vous ne reconnaissez pas une session, modifiez votre mot de passe de connexion et réinitialisez votre mot de passe de messages utilisé pour la sauvegarde des messages.";
 "security_settings_backup" = "SAUVEGARDE DES MESSAGES";

--- a/changelog.d/1193.change
+++ b/changelog.d/1193.change
@@ -1,0 +1,1 @@
+Changer le wording des sections liées à la sécurité et au chiffrement


### PR DESCRIPTION
Fix #1193 

<img width="1014" height="720" alt="image" src="https://github.com/user-attachments/assets/1a4ee825-a869-43cc-9196-cfa62a4af64f" />
