### PR TITLE
Set maximum width constraint for displayname to avoid header room to vanish on iOS 26

### DIFF
--- a/Riot/Modules/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
+++ b/Riot/Modules/MatrixKit/Views/RoomTitle/MXKRoomTitleView.m
@@ -85,6 +85,14 @@ Please see LICENSE in the repository root for full details.
         self.displayNameTextField.enabled = NO;
     }
     self.displayNameTextField.hidden = NO;
+    
+    // Tchap: quick and dirty fix to display long room titles on iOS 26.
+    // Tested on large devices (9)iPhone Air) and narrow devices (iPhone 12 mini).
+    // Field larger than 170.0 pixels is too large and not displayed on iPhone 12 mini running iOS 26.
+    if (@available(iOS 26, *)) {
+        CGFloat maxWidth = 170.0;
+        [self.displayNameTextField.widthAnchor constraintLessThanOrEqualToConstant:maxWidth].active = YES;
+    }
 }
 
 - (void)destroy

--- a/changelog.d/1228.bugfix
+++ b/changelog.d/1228.bugfix
@@ -1,0 +1,1 @@
+Set maximum width constraint for displayname to avoid header room to vanish on iOS 26


### PR DESCRIPTION
Fix #1228

<img width="673" height="720" alt="Simulator Screenshot - iPhone Air - 2025-12-01 at 15 47 40" src="https://github.com/user-attachments/assets/f679322a-2bd7-436b-9b8f-c2f039192155" />
