### PR TITLE
Rétablir la création de compte via MAS 

### DIFF
--- a/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
+++ b/RiotSwiftUI/Modules/Authentication/Common/Service/MatrixSDK/AuthenticationService.swift
@@ -163,9 +163,10 @@ class AuthenticationService: NSObject {
                 homeserver.registrationFlow = try await registrationWizard.registrationFlow()
                 self.registrationWizard = registrationWizard
             } catch {
-                if homeserver.preferredLoginMode.providesDelegatedOIDCCompatibility {
-                    throw RegistrationError.delegatedOIDCRequiresReplacementApp
-                }
+                // Tchap: disable error to continue with MAS Registration
+//                if homeserver.preferredLoginMode.providesDelegatedOIDCCompatibility {
+//                    throw RegistrationError.delegatedOIDCRequiresReplacementApp
+//                }
                 
                 guard homeserver.preferredLoginMode.hasSSO, error as? RegistrationError == .registrationDisabled else {
                     throw error


### PR DESCRIPTION
Issue : https://github.com/tchapgouv/tchap-ios/issues/1280

🐛 Problème identifié depuis la Version 2.12.2

🕵🏻‍♀️ Suite au dernier rebase de Element v1.11.37 et au commit `Support for stable MSC3824`,  le flow MAS de register pour Tchap a été cassé suite à des lignes déplacées dans le catch register de `AuthenticationService.swift‎` 

https://github.com/element-hq/element-ios/commit/9e8f45c68b541926a8fd772701ee9778866194b0#diff-fc3aefbfca6a4be2f9e67750a76d33494dc0d798b1681ea748abbdd18876302fR150-R155