### PR TITLE
MAJ FAQ Urls

### DIFF
--- a/Btchap/Config/BuildSettings.swift
+++ b/Btchap/Config/BuildSettings.swift
@@ -125,7 +125,6 @@ final class BuildSettings: NSObject {
     static let applicationAcceptableUsePolicyUrlString = ""
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
-    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"

--- a/Btchap/Config/BuildSettings.swift
+++ b/Btchap/Config/BuildSettings.swift
@@ -126,7 +126,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
+    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/recevoir-des-notifications-par-e-mail-6k7k89/"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 
     // MARK: - Matrix permalinks

--- a/Btchap/Config/BuildSettings.swift
+++ b/Btchap/Config/BuildSettings.swift
@@ -126,7 +126,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
+    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 

--- a/DevTchap/Config/BuildSettings.swift
+++ b/DevTchap/Config/BuildSettings.swift
@@ -125,7 +125,6 @@ final class BuildSettings: NSObject {
     static let applicationAcceptableUsePolicyUrlString = ""
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
-    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"

--- a/DevTchap/Config/BuildSettings.swift
+++ b/DevTchap/Config/BuildSettings.swift
@@ -126,7 +126,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
+    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/recevoir-des-notifications-par-e-mail-6k7k89/"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 
     // MARK: - Matrix permalinks

--- a/DevTchap/Config/BuildSettings.swift
+++ b/DevTchap/Config/BuildSettings.swift
@@ -126,7 +126,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
+    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 

--- a/Riot/Modules/Settings/SignOut/SignOutAlertPresenter.swift
+++ b/Riot/Modules/Settings/SignOut/SignOutAlertPresenter.swift
@@ -67,16 +67,9 @@ final class SignOutAlertPresenter: NSObject {
             self.delegate?.signOutAlertPresenterDidTapSignOutAction(self)
         }
         
-        // Tchap: add a "More info" button" on sign out.
-        let moreInfoAction = UIAlertAction(title: TchapL10n.signOutExistingKeyBackupAlertLinkMessage, style: .default) { (_) in
-            self.presentingViewController?.present(WebSheetViewController(targetUrl: URL(string: BuildSettings.signoutAlertFaqArticleUrlString)!), animated: true)
-        }
-        
         let cancelAction = UIAlertAction(title: VectorL10n.cancel, style: .cancel)
         
         alertController.addAction(signoutAction)
-        // Tchap: add a "More info" button" on sign out.
-        alertController.addAction(moreInfoAction)
         alertController.addAction(cancelAction)
 
         self.present(alertController: alertController, animated: animated)

--- a/RiotNSE/BuildSettings.swift
+++ b/RiotNSE/BuildSettings.swift
@@ -125,7 +125,6 @@ final class BuildSettings: NSObject {
     static let applicationAcceptableUsePolicyUrlString = ""
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
-    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"

--- a/RiotNSE/BuildSettings.swift
+++ b/RiotNSE/BuildSettings.swift
@@ -126,7 +126,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
+    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/recevoir-des-notifications-par-e-mail-6k7k89/"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 
     // MARK: - Matrix permalinks

--- a/RiotNSE/BuildSettings.swift
+++ b/RiotNSE/BuildSettings.swift
@@ -126,7 +126,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
+    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 

--- a/RiotShareExtension/BuildSettings.swift
+++ b/RiotShareExtension/BuildSettings.swift
@@ -125,7 +125,6 @@ final class BuildSettings: NSObject {
     static let applicationAcceptableUsePolicyUrlString = ""
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
-    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"

--- a/RiotShareExtension/BuildSettings.swift
+++ b/RiotShareExtension/BuildSettings.swift
@@ -126,7 +126,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
+    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/recevoir-des-notifications-par-e-mail-6k7k89/"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 
     // MARK: - Matrix permalinks

--- a/RiotShareExtension/BuildSettings.swift
+++ b/RiotShareExtension/BuildSettings.swift
@@ -126,7 +126,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
+    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
 

--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -140,7 +140,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
+    static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/recevoir-des-notifications-par-e-mail-6k7k89/"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
     
     // MARK: - Matrix permalinks

--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -140,7 +140,7 @@ final class BuildSettings: NSObject {
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
     static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
-    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-impossible-de-mes-messages-comment-y-remedier-iphone-xotgv1"
+    static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"
     

--- a/Tchap/Config/BuildSettings.swift
+++ b/Tchap/Config/BuildSettings.swift
@@ -139,7 +139,6 @@ final class BuildSettings: NSObject {
     static let applicationAcceptableUsePolicyUrlString = ""
     static let proConnectInfoUrlString = "https://proconnect.gouv.fr/"
     static let proConnectAvailabilityFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/se-connecter-a-tchap-avec-proconnect-1dh1peg"
-    static let signoutAlertFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let unableToDecryptFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/dechiffrement-en-cours-mes-messages-restent-verrouilles-atnp15/"
     static let emailNotificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/notification-par-email-draft-6k7k8"
     static let newDeviceVerificationFaqArticleUrlString = "https://aide.tchap.numerique.gouv.fr/fr/article/comment-verifier-un-nouvel-appareil-sur-tchap-xm0b0y"


### PR DESCRIPTION
- Update broken faq url for unable to decrypt 
- Remove "more info" FAQ on sign out (wrong url) 
- Update broken fan url for email notification 